### PR TITLE
accept BytesIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DeepDanbooru is written by Python 3.6. Following packages are need to be install
 - numpy>=1.16.2
 - requests>=2.22.0
 - scikit-image>=0.15.0
+- six>=1.13.0
 
 Or just use `requirements.txt`.
 ```

--- a/deepdanbooru/commands/evaluate.py
+++ b/deepdanbooru/commands/evaluate.py
@@ -1,16 +1,20 @@
 import os
+from typing import Any, Iterable, List, Tuple, Union
 
+import six
 import tensorflow as tf
 
 import deepdanbooru as dd
 
 
-def evaluate_image(image_path: str, model, tags: list, threshold):
+def evaluate_image(
+    image_input: Union[str, six.BytesIO], model: Any, tags: List[str], threshold: float
+) -> Iterable[Tuple[str, float]]:
     width = model.input_shape[2]
     height = model.input_shape[1]
 
     image = dd.data.load_image_for_evaluate(
-        image_path, width=width, height=height)
+        image_input, width=width, height=height)
 
     image_shape = image.shape
     image = image.reshape(

--- a/deepdanbooru/data/__init__.py
+++ b/deepdanbooru/data/__init__.py
@@ -1,13 +1,21 @@
+from typing import Any, Union
+
+import six
 import tensorflow as tf
+
 import deepdanbooru as dd
 
+from .dataset import load_image_records, load_tags
 from .dataset_wrapper import DatasetWrapper
-from .dataset import load_image_records
-from .dataset import load_tags
 
 
-def load_image_for_evaluate(path, width, height, normalize=True):
-    image_raw = tf.io.read_file(path)
+def load_image_for_evaluate(
+        input_: Union[str, six.BytesIO], width: int, height: int, normalize: bool = True
+) -> Any:
+    if isinstance(input_, six.BytesIO):
+        image_raw = input_.getvalue()
+    else:
+        image_raw = tf.io.read_file(input_)
     image = tf.io.decode_png(image_raw, channels=3)
 
     image = tf.image.resize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.16.2
 scikit-image>=0.15.0
 tensorflow>=2.1.0rc1
 requests>=2.22.0
+six>=1.13.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'numpy>=1.16.2',
     'scikit-image>=0.15.0',
     'requests>=2.22.0',
+    'six>=1.13.0',
 ]
 tensorflow_pkg = 'tensorflow>=2.1.0rc1'
 


### PR DESCRIPTION
`evaluate_image `now can accept image BytesIO instead just image filename.

this is needed when the function is used on flask views. in that case the received posted image can be directly processed instead saving it to disk and get image filename

this include test and type hint for both affected function