### PR TITLE
feat: add webp decode support by adding tfio

### DIFF
--- a/deepdanbooru/data/__init__.py
+++ b/deepdanbooru/data/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, Union
 
 import six
 import tensorflow as tf
+import tensorflow_io as tfio
 
 import deepdanbooru as dd
 
@@ -16,7 +17,11 @@ def load_image_for_evaluate(
         image_raw = input_.getvalue()
     else:
         image_raw = tf.io.read_file(input_)
-    image = tf.io.decode_png(image_raw, channels=3)
+    try:
+        image = tf.io.decode_png(image_raw, channels=3)
+    except:
+        image = tfio.image.decode_webp(image_raw)
+        image = tfio.experimental.color.rgba_to_rgb(image)
 
     image = tf.image.resize(
         image,

--- a/deepdanbooru/data/dataset_wrapper.py
+++ b/deepdanbooru/data/dataset_wrapper.py
@@ -2,6 +2,7 @@ import random
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_io as tfio
 
 import deepdanbooru as dd
 
@@ -41,7 +42,11 @@ class DatasetWrapper:
 
     def map_load_image(self, image_path, tag_string):
         image_raw = tf.io.read_file(image_path)
-        image = tf.io.decode_png(image_raw, channels=3)
+        try:
+            image = tf.io.decode_png(image_raw, channels=3)
+        except:
+            image = tfio.image.decode_webp(image_raw)
+            image = tfio.experimental.color.rgba_to_rgb(image)
 
         if self.scale_range:
             pre_scale = self.scale_range[1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ Click>=7.0
 numpy>=1.16.2
 scikit-image>=0.15.0
 tensorflow>=2.3.1
+tensorflow-io>=0.15.0
 requests>=2.22.0
 six>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click>=7.0
 numpy>=1.16.2
 scikit-image>=0.15.0
-tensorflow>=2.3.1
-tensorflow-io>=0.15.0
+tensorflow>=2.7.0
+tensorflow-io>=0.22.0
 requests>=2.22.0
 six>=1.13.0

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ install_requires = [
     "six>=1.13.0",
 ]
 tensorflow_pkg = [
-    "tensorflow>=2.3.1",
-    "tensorflow-io>=0.15.0",
+    "tensorflow>=2.7.0",
+    "tensorflow-io>=0.22.0",
 ]
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ install_requires = [
     "requests>=2.22.0",
     "six>=1.13.0",
 ]
-tensorflow_pkg = "tensorflow>=2.3.1"
+tensorflow_pkg = [
+    "tensorflow>=2.3.1",
+    "tensorflow-io>=0.15.0",
+]
 
 setuptools.setup(
     name="deepdanbooru",


### PR DESCRIPTION
The method
```python
tfio.experimental.color.rgba_to_rgb
```
is experimental and I'm not sure whether this will effect training or predicting. I have tested under the Pretrained Model and found just a little different between webp and png.

> webp format
```bash
(0.999) 1girl
(0.575) areolae
(0.715) arm_up
(0.641) armpits
(0.802) blue_eyes
(0.653) blush
(0.982) breasts
(0.674) brown_hair
(0.515) collarbone
(0.546) double_bun
(0.648) eyebrows_visible_through_hair
(0.956) long_hair
(0.892) looking_at_viewer
(0.820) lying
(0.735) medium_breasts
(0.845) navel
(0.824) nude
(0.778) on_back
(0.682) parted_lips
(0.589) smile
(0.986) solo
(0.956) rating:questionable
```

> png format
```bash
(0.999) 1girl
(0.585) areolae
(0.647) arm_up
(0.626) armpits
(0.681) blue_eyes
(0.655) blush
(0.984) breasts
(0.519) brown_hair
(0.602) collarbone
(0.713) double_bun
(0.731) eyebrows_visible_through_hair
(0.637) hair_bun
(0.967) long_hair
(0.892) looking_at_viewer
(0.855) lying
(0.743) medium_breasts
(0.795) navel
(0.843) nude
(0.838) on_back
(0.746) parted_lips
(0.519) pasties
(0.987) solo
(0.934) rating:questionable
```

