### PR TITLE
Fix cp1252 UnicodeEncodeError

### DIFF
--- a/deepdanbooru/commands/evaluate.py
+++ b/deepdanbooru/commands/evaluate.py
@@ -95,7 +95,11 @@ def evaluate(
         tags = dd.project.load_tags_from_project(project_path)
 
     for image_path in target_image_paths:
-        print(f"Tags of {image_path}:") #yup!
+        try:
+            print(f"Tags of {image_path}") #yup!
+        except UnicodeEncodeError:
+            print(f"Tags of {image_path.encode('ascii', errors='replace').decode('ascii')}:")
+            
         if save_txt: tag_list = []
         for tag, score in evaluate_image(image_path, model, tags, threshold):
             print(f"({score:05.3f}) {tag}")


### PR DESCRIPTION
Simple fix for the following `UnicodeEncodeError` error:
```bash
  File "..\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 25-26: character maps to <undefined>
```

The error occurs when running the script on a file path containing non-ASCII characters, such as Japanese.

To reproduce the error on Windows command line, run the following command:
```bash
python -m deepdanbooru evaluate --project-path ./deepdanbooru-v3-20211112-sgd-e28/ "h:\path to\image\やあ.png" >out
```