### PR TITLE
Allow running as a HTTP service

### DIFF
--- a/deepdanbooru/__main__.py
+++ b/deepdanbooru/__main__.py
@@ -242,6 +242,34 @@ def conv2tflite(project_path, model_path, save_path, optimize_default, optimize_
     if optimize_experimental_sparsity: op.append(tflite.Optimize.EXPERIMENTAL_SPARSITY)
     dd.commands.convert_to_tflite_from_from_saved_model(project_path, model_path, save_path, op, verbose=verbose)
 
+@main.command("serve", help="Host project as a web service.")
+@click.option(
+    "--project-path",
+    type=click.Path(exists=True, resolve_path=True, file_okay=False, dir_okay=True),
+    help="Project path. If you want to use specific model and tags, use --model-path and --tags-path options.",
+)
+@click.option(
+    "--model-path",
+    type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False),
+)
+@click.option(
+    "--tags-path",
+    type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=False),
+)
+@click.option(
+    "--host",
+    default="localhost",
+    help="Provide host for the web service.",
+)
+@click.option(
+    "--port",
+    default=9001,
+    help="Provide port for the web service.",
+)
+@click.option("--allow-gpu", default=False, is_flag=True)
+@click.option("--verbose", default=False, is_flag=True)
+def serve(project_path, model_path, tags_path, host, port, allow_gpu, verbose):
+    dd.commands.serve(project_path, model_path, tags_path, host, port, allow_gpu, verbose)
 
 if __name__ == "__main__":
     main()

--- a/deepdanbooru/commands/__init__.py
+++ b/deepdanbooru/commands/__init__.py
@@ -6,4 +6,5 @@ from .evaluate import evaluate, evaluate_image
 from .grad_cam import grad_cam
 from .make_training_database import make_training_database
 from .train_project import train_project
+from .serve import serve
 

--- a/deepdanbooru/commands/serve.py
+++ b/deepdanbooru/commands/serve.py
@@ -1,0 +1,84 @@
+import os
+import json
+import cgi
+import tensorflow as tf
+from functools import partial
+from six import BytesIO
+from base64 import b64decode
+import deepdanbooru as dd
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from .evaluate import evaluate_image
+
+class WebRequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, model, tags, verbose, *args, **kwargs):
+        self.model = model
+        self.tags = tags
+        self.verbose = verbose
+        super().__init__(*args, **kwargs)
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_headers()
+        self.wfile.write("Requests should be POSTed to this endpoint.".encode("utf-8"))
+
+    def do_POST(self):
+        self._set_headers()
+
+        form = cgi.FieldStorage(
+                 fp=self.rfile,
+                 headers=self.headers,
+                 environ={"REQUEST_METHOD": "POST",
+                          "CONTENT_TYPE": self.headers['Content-Type']})
+
+        b64 = form.getvalue('image')
+        img_data = b64.split(',')[1]
+        image = BytesIO( b64decode(img_data) )
+        threshold = float(form.getvalue('threshold'))
+
+        tags_dict = {}
+        for tag, score in evaluate_image(image, self.model, self.tags, threshold):
+            if self.verbose:
+                print(f"({score:05.3f}) {tag}")
+            tags_dict[tag] = float("{:.3f}".format(score))
+
+        self.wfile.write(json.dumps(tags_dict).encode("utf-8"))
+
+def serve(
+    project_path: str, model_path: str, tags_path: str, host: str, port: int, 
+    allow_gpu: bool, verbose: bool
+):
+    if not allow_gpu:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+    if not model_path and not project_path:
+        raise Exception("You must provide project path or model path.")
+    if not host or not port:
+        raise Exception("You must provide a host and port.")
+
+    if model_path:
+        if verbose:
+            print(f"Loading model from {model_path} ...")
+        model = tf.keras.models.load_model(model_path)
+    else:
+        if verbose:
+            print(f"Loading model from project {project_path} ...")
+        model = dd.project.load_model_from_project(project_path)
+
+    if tags_path:
+        if verbose:
+            print(f"Loading tags from {tags_path} ...")
+        tags = dd.data.load_tags(tags_path)
+    else:
+        if verbose:
+            print(f"Loading tags from project {project_path} ...")
+        tags = dd.project.load_tags_from_project(project_path)
+
+    handler = partial(WebRequestHandler, model, tags, verbose)
+    server = HTTPServer((host, port), handler)
+
+    print("Hoting on http://{}:{}".format(host, port))
+    server.serve_forever()


### PR DESCRIPTION
This PR would allow running DD in a 'server' mode to accept HTTP requests to evaluate images.  

The motivation here is to leverage DD as a resource for other applications/services to tag images as needed:

`deepdanbooru serve --project-path "<dd-project>" --host 0.0.0.0`

Supports arguments:
- `--project-path`
- `--model-path`
- `--tags-path`
- `--host` [localhost]
- `--port` [9001]

Still a little bit of work to do (like supporting SSL certificates), but wanted to open a draft.
